### PR TITLE
feat(securities): generic Issuer template + canonical ClaimTopics library

### DIFF
--- a/contracts/securities/issuers/ClaimTopics.sol
+++ b/contracts/securities/issuers/ClaimTopics.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Lux Partners Limited
+pragma solidity ^0.8.17;
+
+/// @title ClaimTopics
+/// @notice Canonical ERC-735 claim topic numbers. The role-of-issuer that
+///         signs each topic is convention only — the on-chain authority is
+///         `TrustedIssuersRegistry`, which any deployment configures per
+///         jurisdiction. Listed here so every contract / SDK / script imports
+///         the same numbers.
+/// @dev    Topic range allocation:
+///           1-49      identity (IDV provider scope)
+///           50-99     compliance (broker-dealer / accreditation scope)
+///           100-199   transfer-agent (security-token-specific restrictions)
+///           200-299   custody (custodian-specific constraints)
+///           300-399   AML / sanctions (screen-specific)
+///           1000+     custom / experimental (per deployment)
+library ClaimTopics {
+    // ── Identity (1-49) — typically an IDV provider ───────────────────
+    uint256 internal constant ID_VERIFIED       = 1;
+    uint256 internal constant LIVENESS          = 2;
+    uint256 internal constant BIOMETRIC_UNIQUE  = 3;
+    uint256 internal constant JURISDICTION      = 4;
+
+    // ── Compliance (50-99) — typically a broker-dealer ────────────────
+    uint256 internal constant KYC               = 5;
+    uint256 internal constant AML               = 6;
+    uint256 internal constant ACCREDITED        = 7;
+    uint256 internal constant SOURCE_OF_FUNDS   = 8;
+    uint256 internal constant TAX_RESIDENCY     = 9;
+
+    // ── Transfer Agent (100-199) — security-token-specific ────────────
+    uint256 internal constant REG_D_LOCKUP      = 100;
+    uint256 internal constant RULE_144_HOLD     = 101;
+    uint256 internal constant REG_S_NON_US      = 102;
+    uint256 internal constant REG_A_PLUS_TIER1  = 103;
+    uint256 internal constant REG_A_PLUS_TIER2  = 104;
+    uint256 internal constant REG_CF            = 105;
+
+    // ── Signing schemes (ERC-735 `scheme` field) ──────────────────────
+    uint256 internal constant SCHEME_ECDSA      = 1;  // secp256k1 (legacy / classical)
+    uint256 internal constant SCHEME_MLDSA_65   = 2;  // FIPS 204 (post-quantum)
+    uint256 internal constant SCHEME_HYBRID     = 3;  // ECDSA + ML-DSA, both required
+
+    // ── Key purposes (ERC-734) ────────────────────────────────────────
+    uint256 internal constant PURPOSE_MANAGEMENT = 1;
+    uint256 internal constant PURPOSE_ACTION     = 2;
+    uint256 internal constant PURPOSE_CLAIM      = 3;
+    uint256 internal constant PURPOSE_ENCRYPTION = 4;
+}

--- a/contracts/securities/issuers/Issuer.sol
+++ b/contracts/securities/issuers/Issuer.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Lux Partners Limited
+pragma solidity ^0.8.17;
+
+import { ClaimIssuer } from "@luxfi/onchain-id/contracts/ClaimIssuer.sol";
+
+/// @title Issuer
+/// @notice Generic, brand-neutral ERC-735 ClaimIssuer template. Any party
+///         (IDV provider, broker-dealer, transfer agent, registrar, custodian,
+///         AML screen, accreditation verifier) deploys an instance and is
+///         authorised for a topic set in `TrustedIssuersRegistry`.
+/// @dev    On-chain authority is the management key; off-chain signing happens
+///         via the issuer's secp256k1 (or, post-PQ, ML-DSA-65) key registered
+///         on this contract with purpose=3 (CLAIM key). Topic restrictions are
+///         enforced by `TrustedIssuersRegistry`, NOT by this contract — keep
+///         the contract maximally generic so the same template ships across
+///         every regulated role.
+///
+///         Naming convention for deployed instances (off-chain config / docs):
+///           IDV{N}    — identity verification (typically topics 1-4)
+///           BD{N}     — broker-dealer (typically 5-7: KYC/AML/ACCREDITED)
+///           TA{N}     — transfer agent (typically 100+: Reg D / Rule 144 / Reg S)
+///           AML{N}    — AML screening (typically topic 6 alone)
+///           CUSTODY{N}— custodian (jurisdiction-specific)
+///         The {N} index lets multi-tenant deployments coexist
+///         (e.g. BD-liquidity, BD-mlc, BD-vcc).
+contract Issuer is ClaimIssuer {
+    /// @param initialManagementKey Address whose hash becomes the seed
+    ///        MANAGEMENT (purpose 1) key. Required by ERC-734.
+    constructor(address initialManagementKey) ClaimIssuer(initialManagementKey) {}
+}


### PR DESCRIPTION
Single brand-neutral ClaimIssuer template + canonical ERC-735 topic constants. One contract (not three) because authority is the management key and topic restrictions live in TrustedIssuersRegistry — having IDVIssuer/BDIssuer/TAIssuer as separate types would be naming-only and violate 'one and only one way'. Multi-tenant: each org/jurisdiction deploys its own instance(s); brand identity is metadata, not on-chain code. forge build clean.