### PR TITLE
feat(securities/spec): alias TREXFactory as SecurityTokenSuiteFactory

### DIFF
--- a/contracts/securities/spec.sol
+++ b/contracts/securities/spec.sol
@@ -62,7 +62,12 @@ import {
 import {
     ITREXImplementationAuthority as ISecurityTokenAuthority
 } from "@luxfi/erc-3643/contracts/proxy/authority/ITREXImplementationAuthority.sol";
-import {TREXFactory} from "@luxfi/erc-3643/contracts/factory/TREXFactory.sol";
+// Aliased: distinguishes the upstream "deploys a full SecurityToken suite
+// (token + 5 registries + ClaimIssuer wiring) in one tx" factory from
+// Lux's own per-token `SecurityTokenFactory` (`securities/factory/`).
+import {
+    TREXFactory as SecurityTokenSuiteFactory
+} from "@luxfi/erc-3643/contracts/factory/TREXFactory.sol";
 
 // --- ERC-734/735 Identity ----------------------------------------------
 //


### PR DESCRIPTION
Drops the last "TREX" identifier from the consumer-facing surface of securities/spec.sol. Upstream Tokeny TREXFactory deploys a full security-token suite (Token + 5 registries + ClaimIssuer wiring) in one tx; alias it as SecurityTokenSuiteFactory so consumers stay brand-neutral and the name doesn't collide with Lux's own per-token SecurityTokenFactory at securities/factory/SecurityTokenFactory.sol.