### PR TITLE
feat(securities/spec): alias Tokeny Token as SecurityTokenStandard

### DIFF
--- a/contracts/securities/spec.sol
+++ b/contracts/securities/spec.sol
@@ -27,9 +27,20 @@ pragma solidity ^0.8.17;
 // file successfully there. Once the v5 patches land in upstream
 // `@luxfi/erc-3643` main, the skip can be removed.
 
-// --- ERC-3643 token logic + interface ----------------------------------
+// --- Security token logic + interface ----------------------------------
+//
+// `SecurityTokenStandard` is the ERC-3643 reference implementation —
+// proxy-backed, init()-pattern, registered at `SecurityTokenAuthority`
+// and cloned by `SecurityTokenSuiteFactory.deployTREXSuite()`. It is a
+// **security** token, not an ERC-20 / utility token / stablecoin —
+// alias drops the misleading bare `Token` name.
+//
+// Distinct from Lux's own `SecurityToken`
+// (`securities/token/SecurityToken.sol`), which is the constructor-based,
+// AccessControl-driven security token Liquidity uses for production
+// per-issuance deploys via `SecurityTokenFactory.deploy(...)`.
 
-import {Token} from "@luxfi/erc-3643/contracts/token/Token.sol";
+import {Token as SecurityTokenStandard} from "@luxfi/erc-3643/contracts/token/Token.sol";
 import {IToken} from "@luxfi/erc-3643/contracts/token/IToken.sol";
 
 // --- Registry implementations + interfaces -----------------------------


### PR DESCRIPTION
Bare `Token` reads as "ERC-20 / utility token / stablecoin"; the upstream contract is specifically the ERC-3643 reference *security* token. Alias to `SecurityTokenStandard` to remove that ambiguity at the consumer seam.

Distinguishes from Lux's own `SecurityToken` (`securities/token/SecurityToken.sol`), which is the constructor-based, AccessControl-driven security token Liquidity uses for production per-issuance deploys via `SecurityTokenFactory.deploy(...)`. `SecurityTokenStandard` is the proxy-backed, init()-pattern reference registered at `SecurityTokenAuthority` and cloned by `SecurityTokenSuiteFactory.deployTREXSuite()`.

## Test plan

- [x] forge clean && forge build --skip test — exit 0 (skip rule covers spec.sol)
- [x] Downstream consumer (liquidityio/contracts) updated in lockstep