### PR TITLE
docs: add LICENSING.md pointer to canonical Lux IP strategy

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,12 @@
+# Licensing
+
+This repository is licensed under the **BSD 3-Clause License** (see
+[LICENSE](LICENSE)). It belongs to the **public** tier of the Lux
+three-tier IP strategy: anyone may use, fork, or redistribute it,
+including for commercial purposes, subject to the BSD-3 terms.
+
+For the canonical Lux IP and licensing strategy, see:
+<https://github.com/luxfi/.github/blob/main/profile/README.md>
+
+For commercial inquiries that go beyond BSD-3 (e.g. private moat
+acceleration kernels), contact `licensing@lux.network`.


### PR DESCRIPTION
Adds a single LICENSING.md file pointing at the canonical Lux IP and licensing strategy doc on luxfi/.github. LICENSE file unchanged.

Canonical doc: <https://github.com/luxfi/.github/blob/main/profile/README.md>