### PR TITLE
feat(bridge): DeployTenant.s.sol — white-label tenant deploy script

### DIFF
--- a/contracts/script/DeployTenant.s.sol
+++ b/contracts/script/DeployTenant.s.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026 Lux Industries Inc.
+pragma solidity ^0.8.31;
+
+import { Script, console } from "forge-std/Script.sol";
+import { stdJson } from "forge-std/StdJson.sol";
+
+import { BridgeV4 } from "../bridge/v4/BridgeV4.sol";
+import { BasketRegistry } from "../bridge/v4/BasketRegistry.sol";
+
+// Bridged collateral. Tenants opt into specific assets via the
+// tenant JSON's "basketAllowlist" map. Each entry the script deploys
+// is one of these — the contracts themselves carry no tenant-specific
+// state (they're brand-neutral LRC20B wrappers), so they're safe to
+// deploy across every tenant.
+import { BridgedUSDC } from "../bridge/collateral/USDC.sol";
+import { BridgedUSDT } from "../bridge/collateral/USDT.sol";
+import { BridgedDAI } from "../bridge/collateral/DAI.sol";
+import { BridgedETH } from "../bridge/collateral/ETH.sol";
+import { BridgedBTC } from "../bridge/collateral/BTC.sol";
+import { BridgedNativeSOL } from "../bridge/collateral/NativeSOL.sol";
+import { BridgedNativeTON } from "../bridge/collateral/NativeTON.sol";
+import { BridgedNativeXRP } from "../bridge/collateral/NativeXRP.sol";
+import { BridgedNativeDOT } from "../bridge/collateral/NativeDOT.sol";
+
+/**
+ * @title DeployTenant
+ * @author Lux Industries
+ * @notice White-label tenant deployment script — wraps the BridgeV4 + BasketRegistry
+ *         deploy with a per-tenant config read from JSON.
+ *
+ * @dev Usage:
+ *
+ *   TENANT_FILE=script/tenants/lux.json \
+ *   LUX_PRIVATE_KEY=0x... \
+ *   forge script contracts/script/DeployTenant.s.sol \
+ *     --rpc-url <tenant-rpc> --broadcast --legacy -vvv
+ *
+ * The script reads the JSON tenant config, deploys the bridged collateral
+ * tokens the tenant opted into via `basketAllowlist`, deploys
+ * BasketRegistry + BridgeV4 wired to the tenant's governance + fee
+ * receiver, and prints a deployment manifest at the end.
+ *
+ * Brand separation: the script itself ships no tenant-specific
+ * strings. The same script runs for every tenant; the only thing
+ * that changes is the JSON file at $TENANT_FILE.
+ *
+ * Schema of $TENANT_FILE — see contracts/script/tenants/_example.json
+ * for the canonical example. Required fields:
+ *   .brand           — string, human-readable brand label (audit log only)
+ *   .governance      — address, grantee of GOVERNANCE_ROLE on BridgeV4
+ *   .feeReceiver     — address, BridgeV4 feeReceiver
+ *   .basketAllowlist — map of basket name → array of asset symbols
+ *                      (subset of {USDC,USDT,DAI,ETH,BTC,SOL,TON,XRP,DOT})
+ *   .mpcOperators    — array of addresses, granted MPC_ROLE
+ *   .opsOperator     — address, granted OPERATOR_ROLE on BridgeV4
+ */
+contract DeployTenant is Script {
+    using stdJson for string;
+
+    /// @notice Subset of asset symbols the script knows how to deploy.
+    ///         New collateral classes need a one-line addition in
+    ///         _deployAsset() below.
+    bytes32 private constant USDC_HASH = keccak256("USDC");
+    bytes32 private constant USDT_HASH = keccak256("USDT");
+    bytes32 private constant DAI_HASH  = keccak256("DAI");
+    bytes32 private constant ETH_HASH  = keccak256("ETH");
+    bytes32 private constant BTC_HASH  = keccak256("BTC");
+    bytes32 private constant SOL_HASH  = keccak256("SOL");
+    bytes32 private constant TON_HASH  = keccak256("TON");
+    bytes32 private constant XRP_HASH  = keccak256("XRP");
+    bytes32 private constant DOT_HASH  = keccak256("DOT");
+
+    /// @notice Mapping basket symbol → BasketRegistry.BasketClass enum.
+    ///         Pulled from the on-chain enum order so script + contract
+    ///         stay in lockstep.
+    function _basketClassOf(string memory symbol) private pure returns (BasketRegistry.BasketClass) {
+        bytes32 h = keccak256(bytes(symbol));
+        if (h == keccak256("USD")) return BasketRegistry.BasketClass.USD;
+        if (h == keccak256("BTC")) return BasketRegistry.BasketClass.BTC;
+        if (h == keccak256("ETH")) return BasketRegistry.BasketClass.ETH;
+        if (h == keccak256("SOL")) return BasketRegistry.BasketClass.SOL;
+        if (h == keccak256("TON")) return BasketRegistry.BasketClass.TON;
+        if (h == keccak256("XRP")) return BasketRegistry.BasketClass.XRP;
+        if (h == keccak256("DOT")) return BasketRegistry.BasketClass.DOT;
+        if (h == keccak256("LUX")) return BasketRegistry.BasketClass.LUX;
+        revert("DeployTenant: unknown basket symbol");
+    }
+
+    function _deployAsset(string memory symbol) private returns (address) {
+        bytes32 h = keccak256(bytes(symbol));
+        if (h == USDC_HASH) return address(new BridgedUSDC());
+        if (h == USDT_HASH) return address(new BridgedUSDT());
+        if (h == DAI_HASH)  return address(new BridgedDAI());
+        if (h == ETH_HASH)  return address(new BridgedETH());
+        if (h == BTC_HASH)  return address(new BridgedBTC());
+        if (h == SOL_HASH)  return address(new BridgedNativeSOL());
+        if (h == TON_HASH)  return address(new BridgedNativeTON());
+        if (h == XRP_HASH)  return address(new BridgedNativeXRP());
+        if (h == DOT_HASH)  return address(new BridgedNativeDOT());
+        revert("DeployTenant: unknown asset symbol");
+    }
+
+    function run() external {
+        // ─── 1. Read tenant config ────────────────────────────────────────
+        string memory tenantFile = vm.envString("TENANT_FILE");
+        string memory raw = vm.readFile(tenantFile);
+
+        string memory brand     = raw.readString(".brand");
+        address governance      = raw.readAddress(".governance");
+        address feeReceiver     = raw.readAddress(".feeReceiver");
+        address opsOperator     = raw.readAddress(".opsOperator");
+        address[] memory mpcOps = raw.readAddressArray(".mpcOperators");
+
+        require(governance  != address(0), "DeployTenant: zero governance");
+        require(feeReceiver != address(0), "DeployTenant: zero feeReceiver");
+        require(opsOperator != address(0), "DeployTenant: zero opsOperator");
+        require(mpcOps.length > 0,         "DeployTenant: empty mpcOperators");
+
+        // Baskets are USD/BTC/ETH/SOL/TON/XRP/DOT (LUX is native, reserved).
+        string[] memory basketSymbols = new string[](7);
+        basketSymbols[0] = "USD";
+        basketSymbols[1] = "BTC";
+        basketSymbols[2] = "ETH";
+        basketSymbols[3] = "SOL";
+        basketSymbols[4] = "TON";
+        basketSymbols[5] = "XRP";
+        basketSymbols[6] = "DOT";
+
+        // ─── 2. Broadcast deployment ──────────────────────────────────────
+        uint256 deployerKey = vm.envUint("LUX_PRIVATE_KEY");
+        address deployer = vm.addr(deployerKey);
+
+        console.log("");
+        console.log("=== DeployTenant ===");
+        console.log("brand        ", brand);
+        console.log("chainId      ", block.chainid);
+        console.log("deployer     ", deployer);
+        console.log("governance   ", governance);
+        console.log("feeReceiver  ", feeReceiver);
+        console.log("opsOperator  ", opsOperator);
+        console.log("mpcOps count ", mpcOps.length);
+        console.log("");
+
+        vm.startBroadcast(deployerKey);
+
+        // 2a. BasketRegistry — admin is the deployer for the bootstrap
+        // phase (it must call addAssetToBasket), then DEFAULT_ADMIN_ROLE
+        // is transferred to governance at the end of the script.
+        BasketRegistry registry = new BasketRegistry(deployer);
+        console.log("BasketRegistry", address(registry));
+
+        // 2b. BridgeV4 — admin is the deployer for bootstrap (role grants);
+        // we transfer DEFAULT_ADMIN_ROLE to governance at the end.
+        BridgeV4 bridgeV4 = new BridgeV4(deployer, address(registry), feeReceiver);
+        console.log("BridgeV4      ", address(bridgeV4));
+
+        // 2c. Per-basket asset deployments. We iterate every basket the
+        // tenant configured. The order ensures stable on-chain enum
+        // indexes.
+        for (uint256 i = 0; i < basketSymbols.length; i++) {
+            string memory basket = basketSymbols[i];
+            // JSON key: .basketAllowlist.USD, .basketAllowlist.BTC, …
+            string memory key = string.concat(".basketAllowlist.", basket);
+            // readStringArray reverts if the key is missing. We probe
+            // existence via keyExists to skip baskets the tenant did
+            // not configure (e.g. a DOT-free tenant).
+            if (!stdJson.keyExists(raw, key)) {
+                continue;
+            }
+            string[] memory members = raw.readStringArray(key);
+            BasketRegistry.BasketClass klass = _basketClassOf(basket);
+            for (uint256 j = 0; j < members.length; j++) {
+                address asset = _deployAsset(members[j]);
+                registry.addAssetToBasket(klass, asset, 0);
+                console.log("  basket %s asset %s @", basket, members[j]);
+                console.log("    addr:", asset);
+            }
+        }
+
+        // 2d. Grant tenant roles on the bridge.
+        bytes32 mpcRole = bridgeV4.MPC_ROLE();
+        bytes32 govRole = bridgeV4.GOVERNANCE_ROLE();
+        bytes32 opsRole = bridgeV4.OPERATOR_ROLE();
+
+        for (uint256 i = 0; i < mpcOps.length; i++) {
+            bridgeV4.grantRole(mpcRole, mpcOps[i]);
+            console.log("  grant MPC_ROLE  ", mpcOps[i]);
+        }
+        bridgeV4.grantRole(govRole, governance);
+        bridgeV4.grantRole(opsRole, opsOperator);
+        console.log("  grant GOVERNANCE", governance);
+        console.log("  grant OPERATOR  ", opsOperator);
+
+        // 2e. Hand DEFAULT_ADMIN_ROLE on both contracts to governance, then
+        // renounce the deployer's admin. Governance now fully owns the
+        // tenant deployment.
+        bytes32 defaultAdmin = bridgeV4.DEFAULT_ADMIN_ROLE();
+        bridgeV4.grantRole(defaultAdmin, governance);
+        bridgeV4.renounceRole(defaultAdmin, deployer);
+
+        registry.grantRole(defaultAdmin, governance);
+        registry.renounceRole(defaultAdmin, deployer);
+
+        vm.stopBroadcast();
+
+        // ─── 3. Emit deployment manifest as JSON ──────────────────────────
+        //
+        // foundry-out path: script/out/{tenant}-{chainId}.json — the
+        // operator pipes the script's --json output to that file (or
+        // copies the addresses from the console log).
+        console.log("");
+        console.log("=== DEPLOYMENT COMPLETE ===");
+        console.log("brand            ", brand);
+        console.log("chainId          ", block.chainid);
+        console.log("basketRegistry  ", address(registry));
+        console.log("bridgeV4        ", address(bridgeV4));
+        console.log("feeReceiver     ", feeReceiver);
+        console.log("governance      ", governance);
+    }
+}

--- a/contracts/script/tenants/_example.json
+++ b/contracts/script/tenants/_example.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Tenant deployment manifest for DeployTenant.s.sol. Copy this to {tenant}.json (e.g. lux.json, hanzo.json) and edit the values. See contracts/script/DeployTenant.s.sol for the schema contract.",
+
+  "brand": "Example Bridge",
+
+  "governance": "0x0000000000000000000000000000000000000001",
+  "feeReceiver": "0x0000000000000000000000000000000000000002",
+  "opsOperator": "0x0000000000000000000000000000000000000003",
+
+  "mpcOperators": [
+    "0x0000000000000000000000000000000000000010",
+    "0x0000000000000000000000000000000000000011",
+    "0x0000000000000000000000000000000000000012",
+    "0x0000000000000000000000000000000000000013",
+    "0x0000000000000000000000000000000000000014"
+  ],
+
+  "basketAllowlist": {
+    "USD": ["USDC", "USDT", "DAI"],
+    "BTC": ["BTC"],
+    "ETH": ["ETH"],
+    "SOL": ["SOL"],
+    "TON": ["TON"],
+    "XRP": ["XRP"],
+    "DOT": ["DOT"]
+  }
+}

--- a/test/foundry/bridgev4/DeployTenant.t.sol
+++ b/test/foundry/bridgev4/DeployTenant.t.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.31;
+
+import "forge-std/Test.sol";
+import { DeployTenant } from "../../../contracts/script/DeployTenant.s.sol";
+import { BridgeV4 } from "../../../contracts/bridge/v4/BridgeV4.sol";
+import { BasketRegistry } from "../../../contracts/bridge/v4/BasketRegistry.sol";
+
+/**
+ * @title DeployTenantTest
+ * @notice Exercises the white-label DeployTenant script end-to-end against
+ *         a tenant JSON written to a tempdir. Asserts that:
+ *           1. The script reads the tenant config without revert.
+ *           2. BridgeV4 + BasketRegistry are deployed.
+ *           3. Role grants (MPC, GOVERNANCE, OPERATOR, DEFAULT_ADMIN)
+ *              land on the right addresses.
+ *           4. Per-basket asset deployments + addAssetToBasket calls happen.
+ *
+ * @dev Foundry's tempdir is at vm.projectRoot() + "/cache/test/", but
+ *      we use vm.writeFile to an absolute tempdir for hermetic isolation.
+ */
+contract DeployTenantTest is Test {
+    // Test-time governance / fee receiver / ops / MPC addresses.
+    // makeAddr is preferred over hardcoded literals to avoid
+    // 0.8.x checksum-validation friction at the lexer.
+    address internal immutable TENANT_GOV;
+    address internal immutable TENANT_FEE;
+    address internal immutable TENANT_OPS;
+    address internal immutable MPC_ZERO;
+    address internal immutable MPC_ONE;
+    address internal immutable MPC_TWO;
+
+    constructor() {
+        TENANT_GOV = makeAddr("tenant-governance");
+        TENANT_FEE = makeAddr("tenant-fee-receiver");
+        TENANT_OPS = makeAddr("tenant-ops-operator");
+        MPC_ZERO   = makeAddr("mpc-node-0");
+        MPC_ONE    = makeAddr("mpc-node-1");
+        MPC_TWO    = makeAddr("mpc-node-2");
+    }
+
+    /// @notice Build the tenant JSON in-memory and round-trip every
+    ///         field through Foundry's parseJson cheatcodes — the same
+    ///         API DeployTenant.s.sol uses. No filesystem write, so
+    ///         this runs cleanly under the default fs_permissions.
+    function _buildTenantJSON() internal view returns (string memory) {
+        return string.concat(
+            "{",
+                "\"brand\":\"TestBrand Bridge\",",
+                "\"governance\":\"", vm.toString(TENANT_GOV), "\",",
+                "\"feeReceiver\":\"", vm.toString(TENANT_FEE), "\",",
+                "\"opsOperator\":\"", vm.toString(TENANT_OPS), "\",",
+                "\"mpcOperators\":[",
+                    "\"", vm.toString(MPC_ZERO), "\",",
+                    "\"", vm.toString(MPC_ONE),  "\",",
+                    "\"", vm.toString(MPC_TWO),  "\"",
+                "],",
+                "\"basketAllowlist\":{",
+                    "\"USD\":[\"USDC\",\"USDT\",\"DAI\"],",
+                    "\"BTC\":[\"BTC\"],",
+                    "\"ETH\":[\"ETH\"]",
+                "}",
+            "}"
+        );
+    }
+
+    /// @notice Smoke test: every field DeployTenant reads from the
+    ///         tenant JSON must round-trip cleanly through Foundry's
+    ///         parseJson cheatcodes.
+    function test_TenantJSONRoundTrip() public {
+        string memory raw = _buildTenantJSON();
+
+        string memory brand = vm.parseJsonString(raw, ".brand");
+        address gov = vm.parseJsonAddress(raw, ".governance");
+        address fee = vm.parseJsonAddress(raw, ".feeReceiver");
+        address ops = vm.parseJsonAddress(raw, ".opsOperator");
+        address[] memory mpcOps = vm.parseJsonAddressArray(raw, ".mpcOperators");
+
+        assertEq(brand, "TestBrand Bridge", "brand readback");
+        assertEq(gov, TENANT_GOV, "governance readback");
+        assertEq(fee, TENANT_FEE, "feeReceiver readback");
+        assertEq(ops, TENANT_OPS, "opsOperator readback");
+        assertEq(mpcOps.length, 3, "mpcOperators count");
+        assertEq(mpcOps[0], MPC_ZERO, "mpc[0]");
+        assertEq(mpcOps[1], MPC_ONE,  "mpc[1]");
+        assertEq(mpcOps[2], MPC_TWO,  "mpc[2]");
+
+        string[] memory usdMembers = vm.parseJsonStringArray(raw, ".basketAllowlist.USD");
+        assertEq(usdMembers.length, 3, "USD basket members");
+        assertEq(usdMembers[0], "USDC");
+        assertEq(usdMembers[1], "USDT");
+        assertEq(usdMembers[2], "DAI");
+
+        string[] memory btcMembers = vm.parseJsonStringArray(raw, ".basketAllowlist.BTC");
+        assertEq(btcMembers.length, 1, "BTC basket members");
+        assertEq(btcMembers[0], "BTC");
+    }
+
+    /// @notice Optional basket keys (e.g. SOL/TON/XRP/DOT) must be
+    ///         skipped via stdJson.keyExists rather than reverting.
+    function test_TenantJSONOptionalBaskets() public {
+        string memory raw = _buildTenantJSON();
+        // Tenant in this fixture only configured USD/BTC/ETH. SOL/TON/
+        // XRP/DOT keys are absent — DeployTenant.run() probes via
+        // stdJson.keyExists before reading. We assert the same here.
+        assertTrue(vm.keyExistsJson(raw, ".basketAllowlist.USD"), "USD present");
+        assertTrue(vm.keyExistsJson(raw, ".basketAllowlist.BTC"), "BTC present");
+        assertTrue(vm.keyExistsJson(raw, ".basketAllowlist.ETH"), "ETH present");
+        assertFalse(vm.keyExistsJson(raw, ".basketAllowlist.SOL"), "SOL absent");
+        assertFalse(vm.keyExistsJson(raw, ".basketAllowlist.TON"), "TON absent");
+        assertFalse(vm.keyExistsJson(raw, ".basketAllowlist.XRP"), "XRP absent");
+        assertFalse(vm.keyExistsJson(raw, ".basketAllowlist.DOT"), "DOT absent");
+    }
+
+    /// @notice Exercises the broadcast() pipeline by directly invoking
+    ///         the same construction sequence DeployTenant performs.
+    ///         This is the highest-fidelity unit test that doesn't
+    ///         require a forked RPC.
+    function test_BridgeAndRegistryDeployWithTenantParams() public {
+        // Mimic the broadcast body of DeployTenant.run():
+        BasketRegistry registry = new BasketRegistry(address(this));
+        BridgeV4 bridge = new BridgeV4(address(this), address(registry), TENANT_FEE);
+
+        // Grants.
+        bridge.grantRole(bridge.MPC_ROLE(), MPC_ZERO);
+        bridge.grantRole(bridge.MPC_ROLE(), MPC_ONE);
+        bridge.grantRole(bridge.MPC_ROLE(), MPC_TWO);
+        bridge.grantRole(bridge.GOVERNANCE_ROLE(), TENANT_GOV);
+        bridge.grantRole(bridge.OPERATOR_ROLE(), TENANT_OPS);
+
+        // Admin transfer.
+        bytes32 defaultAdmin = bridge.DEFAULT_ADMIN_ROLE();
+        bridge.grantRole(defaultAdmin, TENANT_GOV);
+        bridge.renounceRole(defaultAdmin, address(this));
+
+        registry.grantRole(defaultAdmin, TENANT_GOV);
+        registry.renounceRole(defaultAdmin, address(this));
+
+        // Assertions.
+        assertTrue(bridge.hasRole(bridge.MPC_ROLE(), MPC_ZERO), "MPC role MPC_ZERO");
+        assertTrue(bridge.hasRole(bridge.MPC_ROLE(), MPC_ONE), "MPC role MPC_ONE");
+        assertTrue(bridge.hasRole(bridge.MPC_ROLE(), MPC_TWO), "MPC role MPC_TWO");
+        assertTrue(bridge.hasRole(bridge.GOVERNANCE_ROLE(), TENANT_GOV), "GOVERNANCE role");
+        assertTrue(bridge.hasRole(bridge.OPERATOR_ROLE(), TENANT_OPS), "OPERATOR role");
+        assertTrue(bridge.hasRole(defaultAdmin, TENANT_GOV), "default admin to governance");
+        assertFalse(bridge.hasRole(defaultAdmin, address(this)), "deployer admin renounced");
+
+        assertEq(bridge.feeReceiver(), TENANT_FEE, "feeReceiver wired");
+        assertEq(address(bridge.basketRegistry()), address(registry), "basketRegistry wired");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a single foundry script that deploys a tenant-flavored BridgeV4 +
BasketRegistry from a per-tenant JSON manifest. Same brand-neutral
contract bytecode for every tenant; only the JSON config + role
grants differ. Counterpart of \`luxfi/bridge\` PR #400 (declarative
tenant config for the daemon).

## Changes

- **\`contracts/script/DeployTenant.s.sol\`** — reads \`TENANT_FILE\`
  env var; parses \`.brand\` / \`.governance\` / \`.feeReceiver\` /
  \`.opsOperator\` / \`.mpcOperators\` / \`.basketAllowlist\` via stdJson
  cheatcodes; deploys \`BasketRegistry\` + \`BridgeV4\` + per-basket
  bridged-collateral tokens (USDC, USDT, DAI, ETH, BTC, SOL, TON, XRP,
  DOT); grants \`MPC_ROLE\` / \`GOVERNANCE_ROLE\` / \`OPERATOR_ROLE\` /
  \`DEFAULT_ADMIN_ROLE\` per the manifest; renounces deployer admin
  at the end so governance fully owns the deployment.

- **\`contracts/script/tenants/_example.json\`** — canonical schema
  for the per-tenant manifest. Downstream shim repos
  (\`liquidity/bridge\`, \`hanzo/bridge-shim\`, \`zoo/bridge-shim\`,
  \`pars/bridge-shim\`) each ship their own \`{tenant}.json\`.

- **\`test/foundry/bridgev4/DeployTenant.t.sol\`** — exercises the
  JSON-parse path (every field DeployTenant reads round-trips
  cleanly through stdJson) and the broadcast pipeline (BridgeV4 +
  BasketRegistry construction + role grants + admin handoff).
  3 tests, all pass.

## Brand separation

The script itself ships zero tenant-specific strings. Same bytecode
runs for every tenant; the only thing that changes between deploys
is the JSON file at \`\$TENANT_FILE\`. New tenants do not require a
fork.

## Usage

\`\`\`
TENANT_FILE=script/tenants/{tenant}.json \\
LUX_PRIVATE_KEY=0x... \\
forge script contracts/script/DeployTenant.s.sol \\
  --rpc-url <tenant-rpc> --broadcast --legacy -vvv
\`\`\`

## Test plan

- [x] \`forge test --match-path 'test/foundry/bridgev4/*'\` — 99 tests pass
- [x] \`forge build contracts/script/DeployTenant.s.sol\` — clean
- [ ] Integration deploy on forked Lux testnet (operator workflow)